### PR TITLE
Speed up data extractor

### DIFF
--- a/spynnaker7/pyNN/__init__.py
+++ b/spynnaker7/pyNN/__init__.py
@@ -98,12 +98,17 @@ __all__ = [
     # External devices and extra models
     'external_devices', 'extra_models',
     # Stuff that we define
-    'end', 'setup', 'run', 'get_spynnaker',
+    'end', 'setup', 'run', 'get_spynnaker', 'get_projections_data',
     'num_processes', 'rank', 'reset', 'set_number_of_neurons_per_core',
     'Population', 'Projection',
     'NativeRNG', 'get_current_time', 'create', 'connect', 'get_time_step',
     'get_min_delay', 'get_max_delay', 'set', 'initialize', 'record',
     'record_v', 'record_gsyn', 'get_machine']
+
+
+def get_projections_data(projection_data):
+    return globals_variables.get_simulator().get_projections_data(
+        projection_data)
 
 
 def end():


### PR DESCRIPTION
gives us a 5.4 times speed up on simple synfire chain. likely to give more for larger sims. 

depends upon the following prs:

- [ ] https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/229
- [ ] https://github.com/SpiNNakerManchester/PACMAN/pull/131
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker/pull/429
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker8/pull/84
- [ ] https://github.com/SpiNNakerManchester/SpiNNMan/pull/100
- [ ] https://github.com/SpiNNakerManchester/SpiNNMachine/pull/53
- [ ] https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/71



Note that this work is not finished, but is stable. Future work will come which will increase this even further