### PR TITLE
removed shared sampling interval

### DIFF
--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -3,7 +3,6 @@ from spynnaker.pyNN.models.recording_common import RecordingCommon
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.utilities.constants import \
     SPIKES, MEMBRANE_POTENTIAL, GSYN_INHIB, GSYN_EXCIT
-from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
 from pyNN import descriptions

--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -51,8 +51,7 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         PyNNPopulationCommon.__init__(
             self, spinnaker_control=spinnaker, size=size, vertex=vertex,
             initial_values=None, structure=structure)
-        RecordingCommon.__init__(
-            self, self, globals_variables.get_simulator().machine_time_step)
+        RecordingCommon.__init__(self, self)
 
     @property
     def default_parameters(self):

--- a/unittests/models_tests/neural_properties_tests/test_neural_parameter.py
+++ b/unittests/models_tests/neural_properties_tests/test_neural_parameter.py
@@ -1,13 +1,14 @@
 import unittest
+from data_specification.enums.data_type import DataType
 from spynnaker.pyNN.models.neural_properties.neural_parameter \
     import NeuronParameter
 
 
 class TestingNeuronParameter(unittest.TestCase):
     def test_create_new_neuron_parameter_none_datatype(self):
-        np = NeuronParameter(1, None)
+        np = NeuronParameter(1, DataType.INT64)
         self.assertEqual(np.get_value(), 1)
-        self.assertEqual(np.get_dataspec_datatype(), None)
+        self.assertEqual(np.get_dataspec_datatype(), DataType.INT64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Needed for https://github.com/SpiNNakerManchester/sPyNNaker/pull/442

Sampling interval is not used in pynn 7 and in pynn8 as it can be different per variable I plan to get it from the data