### PR TITLE
Keep data in matrix

### DIFF
--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -401,3 +401,5 @@ class Population(PyNNPopulationCommon, RecordingCommon):
             self.print_v(self._record_v_file)
         if self._record_gsyn_file is not None:
             self.print_gsyn(self._record_gsyn_file)
+
+    def _get_recorded_variable(self, variable):

--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -96,7 +96,7 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         recorded cells.
         """
         self._compatible_output_and_gather_warnings(compatible_output, gather)
-        return self._get_recorded_variable("spikes")
+        return self._get_spikes()
 
     def get_spike_counts(self, gather=True):
         """ Return the number of spikes for each neuron.
@@ -117,13 +117,15 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         """
 
         self._compatible_output_and_gather_warnings(compatible_output, gather)
-        excit = self._get_recorded_variable("gsyn_exc")
-        inhib = self._get_recorded_variable("gsyn_inh")
-        # TODO this needs fixing for seperate recordings of cells on views
-        # and assembliers
-        # merge two arrays into one
-        merged = numpy.hstack((excit, inhib))
-        return numpy.delete(merged, [3, 4], 1)
+        excit = self._get_recorded_pynn7("gsyn_exc")
+        inhib = self._get_recorded_pynn7("gsyn_inh")
+        (exc_data, exc_ids, exc_sampling_interval) = \
+            self._get_recorded_matrix("gsyn_exc")
+        (inh_data, inh_ids, inh_sampling_interval) = \
+            self._get_recorded_matrix("gsyn_inh")
+        # TODO this needs fixing for to check ids and interval are the same
+        return self.pynn7_format(
+            exc_data, exc_ids, exc_sampling_interval, inh_data)
 
     # noinspection PyUnusedLocal
     def get_v(self, gather=True, compatible_output=True):
@@ -137,7 +139,7 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         :type compatible_output: bool
         """
         self._compatible_output_and_gather_warnings(compatible_output, gather)
-        return self._get_recorded_variable(MEMBRANE_POTENTIAL)
+        return self._get_recorded_pynn7(MEMBRANE_POTENTIAL)
 
     @staticmethod
     def _compatible_output_and_gather_warnings(compatible_output, gather):
@@ -399,5 +401,3 @@ class Population(PyNNPopulationCommon, RecordingCommon):
             self.print_v(self._record_v_file)
         if self._record_gsyn_file is not None:
             self.print_gsyn(self._record_gsyn_file)
-
-    def _get_recorded_variable(self, variable):

--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -7,7 +7,6 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
 from pyNN import descriptions
 
-import numpy
 import logging
 
 logger = logging.getLogger(__name__)
@@ -117,8 +116,6 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         """
 
         self._compatible_output_and_gather_warnings(compatible_output, gather)
-        excit = self._get_recorded_pynn7("gsyn_exc")
-        inhib = self._get_recorded_pynn7("gsyn_inh")
         (exc_data, exc_ids, exc_sampling_interval) = \
             self._get_recorded_matrix("gsyn_exc")
         (inh_data, inh_ids, inh_sampling_interval) = \

--- a/spynnaker7/pyNN/models/pynn_population.py
+++ b/spynnaker7/pyNN/models/pynn_population.py
@@ -297,7 +297,7 @@ class Population(PyNNPopulationCommon, RecordingCommon):
         if not gather:
             logger.warn("Spynnaker only supports gather = true, will execute"
                         " as if gather was true anyhow")
-        spikes = self._get_recorded_variable('spikes')
+        spikes = self._get_spikes()
         if spikes is not None:
             utility_calls.check_directory_exists_and_create_if_not(filename)
             spike_file = open(filename, "w")
@@ -313,14 +313,12 @@ class Population(PyNNPopulationCommon, RecordingCommon):
                     printed in
         :param gather: Supported from the PyNN language, but ignored here
         """
-        gsyn_exc = self._get_recorded_variable(GSYN_EXCIT)
-        gsyn_inh = self._get_recorded_variable(GSYN_INHIB)
+        gsyn = self.get_gsyn()
 
         utility_calls.check_directory_exists_and_create_if_not(filename)
         file_handle = open(filename, "w")
-        self._print_headers(file_handle, "gsyn", gsyn_exc.shape[0])
-        for ((neuronId, _, value_e), (_, _, value_i)) in zip(
-                gsyn_exc, gsyn_inh):
+        self._print_headers(file_handle, "gsyn", gsyn.shape[0])
+        for (neuronId, _, value_e, value_i) in gsyn:
             file_handle.write("{}\t{}\t{}\n".format(
                 value_e, value_i, neuronId))
         file_handle.close()
@@ -333,7 +331,7 @@ class Population(PyNNPopulationCommon, RecordingCommon):
                      be printed in
         :param gather: Supported from the PyNN language, but ignored here
         """
-        v = self._get_recorded_variable(MEMBRANE_POTENTIAL)
+        v = self._get_recorded_pynn7(MEMBRANE_POTENTIAL)
         utility_calls.check_directory_exists_and_create_if_not(filename)
         file_handle = open(filename, "w")
         self._print_headers(file_handle, MEMBRANE_POTENTIAL, v.shape[0])

--- a/unittests/models_tests/test_pynn_population.py
+++ b/unittests/models_tests/test_pynn_population.py
@@ -232,7 +232,7 @@ class TestPyNNPopulation(unittest.TestCase):
         sim._buffer_manager = MockBufferManager(recorded_data)
         sim._graph_mapper = graph_mapper
         sim._placements = placements
-
+        sim._no_machine_time_steps = 3
         temp_spikes_file_name = tempfile.mktemp(".dat")
         temp_v_file_name = tempfile.mktemp(".dat")
         temp_gsyn_file_name = tempfile.mktemp(".dat")


### PR DESCRIPTION
This avoids converting v ect data from a matrix to a list or (id, time, value) tuples and then back again for Neo.

Note: get_sampling_interval(self, variable): is in preparation for different ones per variable