### PR TITLE
Multapse connector fixes

### DIFF
--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -12,11 +12,6 @@ class MultapseConnector(CommonMultapseConnector):
 
     :param num_synapses:
         Integer. This is the total number of synapses in the connection.
-    :param allow_self_connections:
-        Bool. Allow a neuron to connect to itself or not.
-    :param with_replacement:
-        Bool. When selecting, allow a neuron to be re-selected or not.
-
     """
     def __init__(self, num_synapses, weights=0.0, delays=1, safe=True,
                  verbose=False):

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -12,6 +12,10 @@ class MultapseConnector(CommonMultapseConnector):
 
     :param num_synapses:
         Integer. This is the total number of synapses in the connection.
+    :param allow_self_connections:
+        Bool. Allow a neuron to connect to itself or not.
+    :param with_replacement:
+        Bool. When selecting, allow a neuron to be re-selected or not.
 
     """
     def __init__(self, num_synapses, weights=0.0, delays=1, safe=True,

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -23,4 +23,3 @@ class MultapseConnector(CommonMultapseConnector):
     def get_rng_next(self, num_synapses, prob_connect):
         return self._rng.next(1, distribution="multinomial",
                               parameters=[num_synapses, prob_connect])
-

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -19,3 +19,8 @@ class MultapseConnector(CommonMultapseConnector):
         CommonMultapseConnector.__init__(
             self, num_synapses=num_synapses, safe=safe, verbose=verbose)
         self.set_weights_and_delays(weights, delays)
+
+    def get_rng_next(self, num_synapses, prob_connect):
+        return self._rng.next(1, distribution="multinomial",
+                              parameters=[num_synapses, prob_connect])
+


### PR DESCRIPTION
Fixes to make MultapseConnector / FixedTotalNumberConnector work again, plus implementation of with_replacement and allow_self_connections.  (Integration tests added to sPyNNaker8 for now, could be copied over here if desired...)

Depends on SpiNNakerManchester/sPyNNaker#474