### PR TITLE
Weights and delays moved in sPyNNaker(8)

### DIFF
--- a/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
+++ b/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
@@ -45,4 +45,3 @@ class AllToAllConnector(CommonAllToAllConnector):
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
+++ b/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
@@ -44,5 +44,5 @@ class AllToAllConnector(CommonAllToAllConnector):
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays
 

--- a/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
+++ b/spynnaker7/pyNN/models/connectors/all_to_all_connector.py
@@ -35,3 +35,14 @@ class AllToAllConnector(CommonAllToAllConnector):
             verbose=verbose)
         self.set_space(space)
         self.set_weights_and_delays(weights, delays)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay
+

--- a/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
@@ -46,3 +46,14 @@ class DistanceDependentProbabilityConnector(
             verbose=verbose, n_connections=n_connections)
         self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay
+

--- a/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
@@ -55,5 +55,5 @@ class DistanceDependentProbabilityConnector(
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays
 

--- a/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker7/pyNN/models/connectors/distance_dependent_probability_connector.py
@@ -56,4 +56,3 @@ class DistanceDependentProbabilityConnector(
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
@@ -61,5 +61,5 @@ class FixedNumberPostConnector(CommonFixedNumberPostConnector):
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays
 

--- a/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
@@ -52,3 +52,14 @@ class FixedNumberPostConnector(CommonFixedNumberPostConnector):
 
         self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay
+

--- a/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_post_connector.py
@@ -62,4 +62,3 @@ class FixedNumberPostConnector(CommonFixedNumberPostConnector):
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
@@ -45,3 +45,14 @@ class FixedNumberPreConnector(CommonFixedNumberPreConnector):
 
         self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay
+

--- a/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
@@ -54,5 +54,5 @@ class FixedNumberPreConnector(CommonFixedNumberPreConnector):
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays
 

--- a/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_number_pre_connector.py
@@ -55,4 +55,3 @@ class FixedNumberPreConnector(CommonFixedNumberPreConnector):
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/fixed_probability_connector.py
+++ b/spynnaker7/pyNN/models/connectors/fixed_probability_connector.py
@@ -36,3 +36,13 @@ class FixedProbabilityConnector(
             verbose=verbose)
         self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delays

--- a/spynnaker7/pyNN/models/connectors/from_list_connector.py
+++ b/spynnaker7/pyNN/models/connectors/from_list_connector.py
@@ -37,3 +37,12 @@ class FromListConnector(CommonFromListConnector):
 
         super(FromListConnector, self).__init__(conns, safe, verbose)
         self.set_weights_and_delays(weights, delays)
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delays
+

--- a/spynnaker7/pyNN/models/connectors/from_list_connector.py
+++ b/spynnaker7/pyNN/models/connectors/from_list_connector.py
@@ -45,4 +45,3 @@ class FromListConnector(CommonFromListConnector):
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -32,4 +32,3 @@ class MultapseConnector(CommonMultapseConnector):
 
     def get_delay(self):
         return self._delays
-

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -22,3 +22,14 @@ class MultapseConnector(CommonMultapseConnector):
     def get_rng_next(self, num_synapses, prob_connect):
         return self._rng.next(1, distribution="multinomial",
                               parameters=[num_synapses, prob_connect])
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay
+

--- a/spynnaker7/pyNN/models/connectors/multapse_connector.py
+++ b/spynnaker7/pyNN/models/connectors/multapse_connector.py
@@ -31,5 +31,5 @@ class MultapseConnector(CommonMultapseConnector):
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays
 

--- a/spynnaker7/pyNN/models/connectors/one_to_one_connector.py
+++ b/spynnaker7/pyNN/models/connectors/one_to_one_connector.py
@@ -19,5 +19,17 @@ class OneToOneConnector(CommonOneToOneConnector):
         """
         super(OneToOneConnector, self).__init__(
             safe=safe, verbose=verbose, random_number_class=RandomDistribution)
-        self.set_weights_and_delays(weights, delays)
+        self._weights = weights
+        self._delays = delays
+        # self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delays

--- a/spynnaker7/pyNN/models/connectors/small_world_connector.py
+++ b/spynnaker7/pyNN/models/connectors/small_world_connector.py
@@ -16,3 +16,13 @@ class SmallWorldConnector(CommonSmallWorldConnector):
             verbose=verbose, n_connections=n_connections)
         self.set_weights_and_delays(weights, delays)
         self.set_space(space)
+
+    def set_weights_and_delays(self, weights, delays):
+        self._weights = weights
+        self._delays = delays
+
+    def get_weight(self):
+        return self._weights
+
+    def get_delay(self):
+        return self._delay

--- a/spynnaker7/pyNN/models/connectors/small_world_connector.py
+++ b/spynnaker7/pyNN/models/connectors/small_world_connector.py
@@ -25,4 +25,4 @@ class SmallWorldConnector(CommonSmallWorldConnector):
         return self._weights
 
     def get_delay(self):
-        return self._delay
+        return self._delays


### PR DESCRIPTION
Moved the weights and delays out of the connectors in sPyNNaker8, but that change meant everything no longer worked with PyNN0.7.  These are part of the changes needed to make it work again.

Depends on https://github.com/SpiNNakerManchester/sPyNNaker/pull/525